### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,9 +26,9 @@
         }
     },
     "require-dev": {
-        "illuminate/database": "^5.5",
-        "illuminate/console": "^5.5",
-        "illuminate/validation": "^5.5",
+        "illuminate/database": "5.5.*",
+        "illuminate/console": "5.5.*",
+        "illuminate/validation": "5.5.*",
         "orchestra/testbench": "^3.5",
         "orchestra/database": "^3.5",
         "phpunit/phpunit": "^6.0",


### PR DESCRIPTION
Laravel doesn't follow semver. So having `^5.x`, `5.*` or `>=5.x` will mean that composer will install a future version even though that version breaks the package.