### PR TITLE
On sending check if attachment is not empty and is not null

### DIFF
--- a/src/Sender.php
+++ b/src/Sender.php
@@ -58,7 +58,7 @@ class Sender
         ];
 
         foreach ((array) $email->getAttachments() as $attachment) {
-            if (!empty($attachment['attachment']['file']) || !is_null($attachment['attachment']['file'])) {
+            if (! empty($attachment['attachment']['file']) || ! is_null($attachment['attachment']['file'])) {
                 call_user_func_array([$message, $attachmentMap[$attachment['type']]], $attachment['attachment']);
             }
         }

--- a/src/Sender.php
+++ b/src/Sender.php
@@ -58,7 +58,9 @@ class Sender
         ];
 
         foreach ((array) $email->getAttachments() as $attachment) {
-            call_user_func_array([$message, $attachmentMap[$attachment['type']]], $attachment['attachment']);
+            if (!empty($attachment['attachment']['file']) || !is_null($attachment['attachment']['file'])) {
+                call_user_func_array([$message, $attachmentMap[$attachment['type']]], $attachment['attachment']);
+            }
         }
     }
 }


### PR DESCRIPTION
In the case of an empty variable in ->attach() still data is set, but file remains empty. On sending check if this is not empty or null before actually adding the attachment to the mail.