### PR TITLE
UPDATE: Manual migrations option

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ composer require stackkit/laravel-database-emails
 Publish the configuration files.
 
 ```bash
-php artisan vendor:publish --provider=Stackkit\\LaravelDatabaseEmails\\LaravelDatabaseEmailsServiceProvider
+php artisan vendor:publish --tag=laravel-database-emails-config
 ```
 
 Create the database table required for this package.

--- a/config/laravel-database-emails.php
+++ b/config/laravel-database-emails.php
@@ -71,4 +71,17 @@ return [
     */
 
     'immediately' => env('LARAVEL_DATABASE_EMAILS_SEND_IMMEDIATELY', false),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Manual migrations
+    |--------------------------------------------------------------------------
+    |
+    | This option allows you to use:
+    | `php artisan vendor:publish --tag=laravel-database-emails-migrations` to push migrations
+    | to your app's folder so you're free to modify before migrating.
+    |
+    */
+
+    'manual_migrations' => (bool) env('LARAVEL_DATABASE_EMAILS_MANUAL_MIGRATIONS', false),
 ];

--- a/src/Email.php
+++ b/src/Email.php
@@ -52,7 +52,7 @@ class Email extends Model
      */
     public static function compose()
     {
-        return new EmailComposer(new self);
+        return new EmailComposer(new static);
     }
 
     /**

--- a/src/LaravelDatabaseEmailsServiceProvider.php
+++ b/src/LaravelDatabaseEmailsServiceProvider.php
@@ -13,15 +13,42 @@ class LaravelDatabaseEmailsServiceProvider extends ServiceProvider
      */
     public function boot()
     {
+        $this->bootConfig();
+        $this->bootDatabase();
+    }
+
+    /**
+     * Boot the config for the package.
+     *
+     * @return void
+     */
+    private function bootConfig(): void
+    {
         $baseDir = __DIR__ . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR;
         $configDir = $baseDir . 'config' . DIRECTORY_SEPARATOR;
-        $migrationsDir = $baseDir . 'database' . DIRECTORY_SEPARATOR . 'migrations' . DIRECTORY_SEPARATOR;
 
         $this->publishes([
             $configDir . 'laravel-database-emails.php' => config_path('laravel-database-emails.php'),
-        ]);
+        ], 'laravel-database-emails-config');
+    }
 
-        $this->loadMigrationsFrom([$migrationsDir]);
+    /**
+     * Boot the database for the package.
+     *
+     * @return void
+     */
+    private function bootDatabase(): void
+    {
+        $baseDir = __DIR__ . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR;
+        $migrationsDir = $baseDir . 'database' . DIRECTORY_SEPARATOR . 'migrations' . DIRECTORY_SEPARATOR;
+
+        if ($this->app['config']->get('laravel-database-emails.manual_migrations')) {
+            $this->publishes([
+                $migrationsDir => "{$this->app->databasePath()}/migrations",
+            ], 'laravel-database-emails-migrations');
+        } else {
+            $this->loadMigrationsFrom([$migrationsDir]);
+        }
     }
 
     /**


### PR DESCRIPTION
In order to make this package compatible with [stancl/tenancy](https://github.com/archtechx/tenancy) migrations have to be applied on tenant level, 
to achieve it, I've added new config option:
`'manual_migrations' => (bool) env('LARAVEL_DATABASE_EMAILS_MANUAL_MIGRATIONS', false),`

I've also added tags to each publish of the service provider (to separate them & to make initial install less cumbersome)