### PR TITLE
UPDATE: Email queued_at field

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,7 +1,7 @@
 name: Run tests
 
 on:
-  push:
+  pull_request:
   schedule:
     - cron: '0 0 * * *'
 

--- a/database/migrations/2021_12_02_21000_add_queued_at_to_emails_table.php
+++ b/database/migrations/2021_12_02_21000_add_queued_at_to_emails_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddQueuedAtToEmailsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        if (Schema::hasColumn('emails', 'queued_at')) {
+            return;
+        }
+
+        Schema::table('emails', function (Blueprint $table) {
+            $table->timestamp('queued_at')->after('encrypted')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        //
+    }
+}

--- a/src/Email.php
+++ b/src/Email.php
@@ -23,6 +23,7 @@ use Illuminate\Database\Eloquent\Model;
  * @property $failed
  * @property $error
  * @property $encrypted
+ * @property $queued_at
  * @property $scheduled_at
  * @property $sent_at
  * @property $delivered_at
@@ -275,6 +276,30 @@ class Email extends Model
     public function getAttempts()
     {
         return $this->attempts;
+    }
+
+    /**
+     * Get the queued date.
+     *
+     * @return mixed
+     */
+    public function getQueuedDate()
+    {
+        return $this->queued_at;
+    }
+
+    /**
+     * Get the queued date as a Carbon instance.
+     *
+     * @return Carbon
+     */
+    public function getQueuedDateAsCarbon()
+    {
+        if ($this->queued_at instanceof Carbon) {
+            return $this->queued_at;
+        }
+
+        return Carbon::parse($this->queued_at);
     }
 
     /**

--- a/src/Preparer.php
+++ b/src/Preparer.php
@@ -36,6 +36,8 @@ class Preparer
         $this->prepareScheduled($composer);
 
         $this->prepareImmediately($composer);
+
+        $this->prepareQueued($composer);
     }
 
     /**
@@ -235,4 +237,19 @@ class Preparer
             $composer->getEmail()->fill(['sending' => 1]);
         }
     }
+
+    /**
+     * Prepare the queued date.
+     *
+     * @param EmailComposer $composer
+     */
+    private function prepareQueued(EmailComposer $composer)
+    {
+        if ($this->getData('queued', false) === true) {
+            $composer->getEmail()->fill([
+                'queued_at' => Carbon::now()->toDateTimeString(),
+            ]);
+        }
+    }
+
 }

--- a/src/Preparer.php
+++ b/src/Preparer.php
@@ -245,7 +245,7 @@ class Preparer
      */
     private function prepareQueued(EmailComposer $composer)
     {
-        if ($this->getData('queued', false) === true) {
+        if ($composer->getData('queued', false) === true) {
             $composer->getEmail()->fill([
                 'queued_at' => Carbon::now()->toDateTimeString(),
             ]);

--- a/src/Store.php
+++ b/src/Store.php
@@ -19,6 +19,7 @@ class Store
         return $query
             ->whereNull('deleted_at')
             ->whereNull('sent_at')
+            ->whereNull('queued_at')
             ->where(function ($query) {
                 $query->whereNull('scheduled_at')
                     ->orWhere('scheduled_at', '<=', Carbon::now()->toDateTimeString());

--- a/tests/QueuedEmailsTest.php
+++ b/tests/QueuedEmailsTest.php
@@ -22,6 +22,14 @@ class QueuedEmailsTest extends TestCase
     }
 
     /** @test */
+    public function queueing_an_email_will_set_the_queued_at_column()
+    {
+        $email = $this->queueEmail();
+
+        $this->assertNotNull($email->queued_at);
+    }
+
+    /** @test */
     public function queueing_an_email_will_dispatch_a_job()
     {
         Queue::fake();

--- a/tests/SendEmailsCommandTest.php
+++ b/tests/SendEmailsCommandTest.php
@@ -4,6 +4,7 @@ namespace Tests;
 
 use Carbon\Carbon;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Queue;
 use Stackkit\LaravelDatabaseEmails\Store;
 
 class SendEmailsCommandTest extends TestCase
@@ -43,6 +44,18 @@ class SendEmailsCommandTest extends TestCase
 
         $this->assertEquals(1, $email->fresh()->getAttempts());
         $this->assertEquals($firstSend, $email->fresh()->getSendDate());
+    }
+
+    /** @test */
+    public function an_email_should_not_be_sent_if_it_is_queued()
+    {
+        Queue::fake();
+
+        $email = $this->queueEmail();
+
+        $this->artisan('email:send');
+
+        $this->assertNull($email->fresh()->getSendDate());
     }
 
     /** @test */


### PR DESCRIPTION
Currently if `SendEmailsCommand` is used with queuing e-mails from `EmailComposer` - it might result in sent email duplicates

I've added `queued_at` field to `Email` model
It will be populated after `EmailComposer::queue()` is called
`SendEmailsCommand` will now check for non queued emails