### PR TITLE
Load matrix from JSON

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -57,18 +57,30 @@ jobs:
               throw "Action was not authorized. Exiting now."
             }
 
-  php-tests:
+  load-matrix:
     runs-on: ubuntu-latest
     needs: access_check
+    outputs:
+      db: ${{ steps.load.outputs.db }}
+      payload: ${{ steps.load.outputs.payload }}
+    steps:
+      - name: Checkout PR code to read matrix.json
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - name: Load matrix
+        id: load
+        run: |
+          echo "db=$(jq -c '.db' matrix.json)" >> $GITHUB_OUTPUT
+          echo "payload=$(jq -c '.payload' matrix.json)" >> $GITHUB_OUTPUT
+
+  php-tests:
+    runs-on: ubuntu-latest
+    needs: load-matrix
     strategy:
       matrix:
-        db: [ 'mysql', 'sqlite', 'pgsql' ]
-        payload:
-          - { laravel: '11.*', php: '8.3', 'testbench': '9.*', collision: '8.*' }
-          - { laravel: '11.*', php: '8.2', 'testbench': '9.*', collision: '8.*' }
-          - { laravel: '12.*', php: '8.2', 'testbench': '10.*', collision: '8.*' }
-          - { laravel: '12.*', php: '8.3', 'testbench': '10.*', collision: '8.*' }
-          - { laravel: '12.*', php: '8.4', 'testbench': '10.*', collision: '8.*' }
+        db: ${{ fromJson(needs.load-matrix.outputs.db) }}
+        payload: ${{ fromJson(needs.load-matrix.outputs.payload) }}
 
     name: PHP ${{ matrix.payload.php }} - Laravel ${{ matrix.payload.laravel }} - DB ${{ matrix.db }}
 

--- a/matrix.json
+++ b/matrix.json
@@ -1,0 +1,10 @@
+{
+  "db": ["mysql", "sqlite", "pgsql"],
+  "payload": [
+    { "laravel": "11.*", "php": "8.3", "testbench": "9.*", "collision": "8.*" },
+    { "laravel": "11.*", "php": "8.2", "testbench": "9.*", "collision": "8.*" },
+    { "laravel": "12.*", "php": "8.2", "testbench": "10.*", "collision": "8.*" },
+    { "laravel": "12.*", "php": "8.3", "testbench": "10.*", "collision": "8.*" },
+    { "laravel": "12.*", "php": "8.4", "testbench": "10.*", "collision": "8.*" }
+  ]
+}


### PR DESCRIPTION
## Summary

- Extracts the test matrix into a `matrix.json` file at the repo root
- Adds a `load-matrix` job that checks out the PR code and reads the matrix via `jq`
- The `php-tests` job now consumes the matrix via `fromJson(needs.load-matrix.outputs.*)`

This mirrors the same pattern already in use in `laravel-google-cloud-tasks-queue`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)