### PR TITLE
Add Laravel 13 support, drop Laravel 11

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -82,7 +82,7 @@ jobs:
         db: ${{ fromJson(needs.load-matrix.outputs.db) }}
         payload: ${{ fromJson(needs.load-matrix.outputs.payload) }}
 
-    name: PHP ${{ matrix.payload.php }} - Laravel ${{ matrix.payload.laravel }} - DB ${{ matrix.db }}
+    name: PHP ${{ matrix.payload.php }} - Laravel ${{ matrix.payload.laravel }} - DB ${{ matrix.db.version != '' && format('{0} {1}', matrix.db.driver, matrix.db.version) || matrix.db.driver }}
 
     steps:
       - name: Checkout code
@@ -99,15 +99,15 @@ jobs:
 
       - name: Set up MySQL and PostgreSQL
         run: |
-            if [ "${{ matrix.db }}" != "sqlite" ]; then
-                MYSQL_PORT=3307 POSTGRES_PORT=5432 docker compose up ${{ matrix.db }} -d
+            if [ "${{ matrix.db.driver }}" != "sqlite" ]; then
+                MYSQL_PORT=3307 POSTGRES_PORT=5432 docker compose up ${{ matrix.db.driver }} -d
             fi
 
       - name: Install dependencies
         run: |
           composer require "laravel/framework:${{ matrix.payload.laravel }}" "orchestra/testbench:${{ matrix.payload.testbench }}" "nunomaduro/collision:${{ matrix.payload.collision }}" --no-interaction --no-update
           composer update --prefer-stable --prefer-dist --no-interaction
-          if [ "${{ matrix.db }}" = "mysql" ]; then
+          if [ "${{ matrix.db.driver }}" = "mysql" ]; then
             while ! mysqladmin ping --host=127.0.0.1 --user=test --port=3307 --password=test --silent; do
               echo "Waiting for MySQL..."
               sleep 1
@@ -117,5 +117,5 @@ jobs:
           fi
       - name: Execute tests
         env:
-          DB_DRIVER: ${{ matrix.db }}
+          DB_DRIVER: ${{ matrix.db.driver }}
         run: composer test

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -82,7 +82,7 @@ jobs:
         db: ${{ fromJson(needs.load-matrix.outputs.db) }}
         payload: ${{ fromJson(needs.load-matrix.outputs.payload) }}
 
-    name: PHP ${{ matrix.payload.php }} - Laravel ${{ matrix.payload.laravel }} - DB ${{ matrix.db.label }}
+    name: PHP ${{ matrix.payload.php }} - Laravel ${{ matrix.payload.laravel }} - DB ${{ matrix.db }}
 
     steps:
       - name: Checkout code
@@ -99,15 +99,15 @@ jobs:
 
       - name: Set up MySQL and PostgreSQL
         run: |
-            if [ "${{ matrix.db.driver }}" != "sqlite" ]; then
-                MYSQL_PORT=3307 POSTGRES_PORT=5432 docker compose up ${{ matrix.db.driver }} -d
+            if [ "${{ matrix.db }}" != "sqlite" ]; then
+                MYSQL_PORT=3307 POSTGRES_PORT=5432 docker compose up ${{ matrix.db }} -d
             fi
 
       - name: Install dependencies
         run: |
           composer require "laravel/framework:${{ matrix.payload.laravel }}" "orchestra/testbench:${{ matrix.payload.testbench }}" "nunomaduro/collision:${{ matrix.payload.collision }}" --no-interaction --no-update
           composer update --prefer-stable --prefer-dist --no-interaction
-          if [ "${{ matrix.db.driver }}" = "mysql" ]; then
+          if [ "${{ matrix.db }}" = "mysql" ]; then
             while ! mysqladmin ping --host=127.0.0.1 --user=test --port=3307 --password=test --silent; do
               echo "Waiting for MySQL..."
               sleep 1
@@ -116,4 +116,4 @@ jobs:
             echo "Not waiting for MySQL."
           fi
       - name: Execute tests
-        run: DB_DRIVER=${{ matrix.db.driver }} composer test
+        run: DB_DRIVER=${{ matrix.db }} composer test

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -82,7 +82,7 @@ jobs:
         db: ${{ fromJson(needs.load-matrix.outputs.db) }}
         payload: ${{ fromJson(needs.load-matrix.outputs.payload) }}
 
-    name: PHP ${{ matrix.payload.php }} - Laravel ${{ matrix.payload.laravel }} - DB ${{ matrix.db.version != '' && format('{0} {1}', matrix.db.driver, matrix.db.version) || matrix.db.driver }}
+    name: PHP ${{ matrix.payload.php }} - Laravel ${{ matrix.payload.laravel }} - DB ${{ matrix.db.label }}
 
     steps:
       - name: Checkout code

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -116,6 +116,4 @@ jobs:
             echo "Not waiting for MySQL."
           fi
       - name: Execute tests
-        env:
-          DB_DRIVER: ${{ matrix.db.driver }}
-        run: composer test
+        run: DB_DRIVER=${{ matrix.db.driver }} composer test

--- a/composer.json
+++ b/composer.json
@@ -30,23 +30,23 @@
     },
     "require": {
         "ext-json": "*",
-        "laravel/framework": "^11.0|^12.0",
+        "laravel/framework": "^12.0|^13.0",
         "doctrine/dbal": "^4.0"
     },
     "require-dev": {
         "mockery/mockery": "^1.2",
-        "orchestra/testbench": "^9.0|^10.0",
+        "orchestra/testbench": "^10.0|^11.0",
         "nunomaduro/collision": "^8.0",
         "laravel/pint": "^1.14"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,
     "scripts": {
-        "l11": [
-            "composer update laravel/framework:11.* orchestra/testbench:9.* nunomaduro/collision:8.* --with-all-dependencies"
-        ],
         "l12": [
             "composer update laravel/framework:12.* orchestra/testbench:10.* nunomaduro/collision:8.* --with-all-dependencies"
+        ],
+        "l13": [
+            "composer update laravel/framework:13.* orchestra/testbench:11.* nunomaduro/collision:8.* --with-all-dependencies"
         ],
         "test": [
             "testbench workbench:create-sqlite-db",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     volumes:
       - .:/var/www/html
   mysql:
-    image: mysql:8
+    image: mysql:8.4
     ports:
       - '${MYSQL_PORT:-3307}:3306'
     environment:
@@ -13,7 +13,7 @@ services:
       MYSQL_DATABASE: 'test'
       MYSQL_RANDOM_ROOT_PASSWORD: true
   pgsql:
-    image: postgres:14
+    image: postgres:16
     ports:
       - '${POSTGRES_PORT:-5432}:5432'
     environment:

--- a/matrix.json
+++ b/matrix.json
@@ -1,8 +1,8 @@
 {
   "db": [
-    { "driver": "mysql", "version": "8.4" },
-    { "driver": "sqlite" },
-    { "driver": "pgsql", "version": "16" }
+    { "driver": "mysql", "version": "8.4", "label": "mysql 8.4" },
+    { "driver": "sqlite", "label": "sqlite" },
+    { "driver": "pgsql", "version": "16", "label": "pgsql 16" }
   ],
   "payload": [
     { "laravel": "12.*", "php": "8.2", "testbench": "10.*", "collision": "8.*" },

--- a/matrix.json
+++ b/matrix.json
@@ -4,7 +4,9 @@
     { "laravel": "12.*", "php": "8.2", "testbench": "10.*", "collision": "8.*" },
     { "laravel": "12.*", "php": "8.3", "testbench": "10.*", "collision": "8.*" },
     { "laravel": "12.*", "php": "8.4", "testbench": "10.*", "collision": "8.*" },
+    { "laravel": "12.*", "php": "8.5", "testbench": "10.*", "collision": "8.*" },
     { "laravel": "13.*", "php": "8.3", "testbench": "11.*", "collision": "8.*" },
-    { "laravel": "13.*", "php": "8.4", "testbench": "11.*", "collision": "8.*" }
+    { "laravel": "13.*", "php": "8.4", "testbench": "11.*", "collision": "8.*" },
+    { "laravel": "13.*", "php": "8.5", "testbench": "11.*", "collision": "8.*" }
   ]
 }

--- a/matrix.json
+++ b/matrix.json
@@ -1,10 +1,10 @@
 {
   "db": ["mysql", "sqlite", "pgsql"],
   "payload": [
-    { "laravel": "11.*", "php": "8.3", "testbench": "9.*", "collision": "8.*" },
-    { "laravel": "11.*", "php": "8.2", "testbench": "9.*", "collision": "8.*" },
     { "laravel": "12.*", "php": "8.2", "testbench": "10.*", "collision": "8.*" },
     { "laravel": "12.*", "php": "8.3", "testbench": "10.*", "collision": "8.*" },
-    { "laravel": "12.*", "php": "8.4", "testbench": "10.*", "collision": "8.*" }
+    { "laravel": "12.*", "php": "8.4", "testbench": "10.*", "collision": "8.*" },
+    { "laravel": "13.*", "php": "8.3", "testbench": "11.*", "collision": "8.*" },
+    { "laravel": "13.*", "php": "8.4", "testbench": "11.*", "collision": "8.*" }
   ]
 }

--- a/matrix.json
+++ b/matrix.json
@@ -1,5 +1,9 @@
 {
-  "db": ["mysql", "sqlite", "pgsql"],
+  "db": [
+    { "driver": "mysql", "version": "8.4" },
+    { "driver": "sqlite" },
+    { "driver": "pgsql", "version": "16" }
+  ],
   "payload": [
     { "laravel": "12.*", "php": "8.2", "testbench": "10.*", "collision": "8.*" },
     { "laravel": "12.*", "php": "8.3", "testbench": "10.*", "collision": "8.*" },

--- a/matrix.json
+++ b/matrix.json
@@ -1,9 +1,5 @@
 {
-  "db": [
-    { "driver": "mysql", "version": "8.4", "label": "mysql 8.4" },
-    { "driver": "sqlite", "label": "sqlite" },
-    { "driver": "pgsql", "version": "16", "label": "pgsql 16" }
-  ],
+  "db": ["mysql", "sqlite", "pgsql"],
   "payload": [
     { "laravel": "12.*", "php": "8.2", "testbench": "10.*", "collision": "8.*" },
     { "laravel": "12.*", "php": "8.3", "testbench": "10.*", "collision": "8.*" },


### PR DESCRIPTION
## Summary

- Adds Laravel 13 support (`^13.0`) with testbench `11.*`
- Drops Laravel 11 support
- Updates `composer.json` require constraints and adds `l13` composer script
- Updates `matrix.json` to replace Laravel 11 entries with Laravel 13 (PHP 8.3 & 8.4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)